### PR TITLE
css tech (former css-fast) doesn't work

### DIFF
--- a/lib/techs/css.js
+++ b/lib/techs/css.js
@@ -89,6 +89,14 @@ exports.Tech = INHERIT(cssbase.Tech, {
     })
 });
 
+function isIncludeProcessable(url) {
+   return !isAbsoluteUrl(url);
+}
+
+function isAbsoluteUrl(url) {
+    return /^\w+:/.test(url);
+}
+
 function parseUrl(url) {
     if (url.lastIndexOf('url(', 0) === 0) url = url.replace(/^url\(\s*/, '').replace(/\s*\)$/, '');
 


### PR DESCRIPTION
because "isIncludeProcessable" is not defined
